### PR TITLE
a50-common: Add additional UDFPS properties

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -29,6 +29,18 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <!-- The radius of the enrollment progress bar, in dp -->
     <integer name="config_udfpsEnrollProgressBar" translatable="false">110</integer>
 
+    <!-- Color of the FOD view -->
+    <color name="config_udfpsColor">#00ff00ff</color>
+
+    <!-- HBM type of UDFPS overlay.
+            0 - GLOBAL HBM
+            1 - LOCAL HBM
+    -->
+    <integer name="config_udfps_hbm_type">0</integer>
+
+    <!-- Udfps vendor code -->
+    <integer name="config_udfps_vendor_code">455</integer>
+
     <!-- Enable doze mode -->
     <bool name="doze_display_state_supported">true</bool>
 </resources>


### PR DESCRIPTION
Set UDFPS to use global HBM (our display HALs don't support local HBM) and set vendor code to wake screen up to keycode 455 according to kernel. This requires a ROM with the custom UDFPS commits in (which should be most of them at this point). This also makes the FOD location in the correct place.

We still need to fix actual enrollment. Maybe in the HAL, perhaps?